### PR TITLE
Updated README.md and README.Rmd to Specify Deployment Branch Name

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -104,7 +104,7 @@ Last step is commit to GitHub, wait until the GitHub action ends (in the
 case you chose to deploy in that way) and deploy the website via
 *YOUR\_GITHUB\_REPO\>Settings\>GitHub Pages*.
 
-Please note: it may take 24 hours or more before your website is updated. 
+Please note: after you commit, it may take 24 hours or more until your website is updated. 
 
 ## Extras
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,11 +39,12 @@ not automatic.
 
 ### Option A: Deploy using GitHub Actions
 
-It is not necessary to install **rogtemplate** itself. Just copy 
-[this file](https://github.com/rOpenGov/rogtemplate/blob/main/inst/yaml/rogtemplate-gh-pages.yaml) 
+It is not necessary to install **rogtemplate** itself. First copy [this
+file](https://github.com/rOpenGov/rogtemplate/blob/main/inst/yaml/rogtemplate-gh-pages.yaml)
 into your `.github/workflows/` folder.
 
-The action would create your site in the `gh-pages` branch.
+Next go to *YOUR_GITHUB_REPO>Settings>GitHub Pages* and create a branch named `gh-pages`.  
+**rogtemplate** needs to be deployed from this branch.
 
 ### Option B: Deploy installing rogtemplate
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -104,6 +104,7 @@ Last step is commit to GitHub, wait until the GitHub action ends (in the
 case you chose to deploy in that way) and deploy the website via
 *YOUR\_GITHUB\_REPO\>Settings\>GitHub Pages*.
 
+Please note: it may take 24 hours or more before your website is updated. 
 
 ## Extras
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Last step is commit to GitHub, wait until the GitHub action ends (in the
 case you chose to deploy in that way) and deploy the website via
 *YOUR_GITHUB_REPO>Settings>GitHub Pages*.
 
+Please note: it may take 24 hours or more before your website is updated. 
+
 ## Extras
 
 We provide also some additional extra functions for creating badges and

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ It is not necessary to install **rogtemplate** itself. First copy [this
 file](https://github.com/rOpenGov/rogtemplate/blob/main/inst/yaml/rogtemplate-gh-pages.yaml)
 into your `.github/workflows/` folder.
 
-Next go to *YOUR_GITHUB_REPO>Settings>GitHub Pages* and create a branch named `gh-pages`.  **rogtemplate** needs to be deployed from this branch.
+Next go to *YOUR_GITHUB_REPO>Settings>GitHub Pages* and create a branch named `gh-pages`.  
+**rogtemplate** needs to be deployed from this branch.
 
 ### Option B: Deploy installing rogtemplate
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Last step is commit to GitHub, wait until the GitHub action ends (in the
 case you chose to deploy in that way) and deploy the website via
 *YOUR_GITHUB_REPO>Settings>GitHub Pages*.
 
-Please note: it may take 24 hours or more before your website is updated. 
+Please note: after you commit, it may take 24 hours or more until your website is updated. 
 
 ## Extras
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ control but it is not automatic.
 
 ### Option A: Deploy using GitHub Actions
 
-It is not necessary to install **rogtemplate** itself. Just copy [this
+It is not necessary to install **rogtemplate** itself. First copy [this
 file](https://github.com/rOpenGov/rogtemplate/blob/main/inst/yaml/rogtemplate-gh-pages.yaml)
 into your `.github/workflows/` folder.
 
-The action would create your site in the `gh-pages` branch.
+Next go to *YOUR_GITHUB_REPO>Settings>GitHub Pages* and create a branch named `gh-pages`.  **rogtemplate** needs to be deployed from this branch.
 
 ### Option B: Deploy installing rogtemplate
 


### PR DESCRIPTION
Updated **README.md** and **README.Rmd** to specify that the name of the deployment branch must be **gh-pages** and that the user must create this branch (this branch is not automatically created by the yaml file, or any other file). 